### PR TITLE
refactor: Remove unused event listeners from media-lightbox.js

### DIFF
--- a/assets/js/media-lightbox.js
+++ b/assets/js/media-lightbox.js
@@ -19,6 +19,4 @@
     initLightbox();
   }
 
-  document.addEventListener("turbo:load", initLightbox);
-  document.addEventListener("astro:after-swap", initLightbox);
 })();


### PR DESCRIPTION
Removed event listeners for 'turbo:load' and 'astro:after-swap'.